### PR TITLE
Implementación de una brújula

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -2,12 +2,12 @@
 <project version="4">
   <component name="deploymentTargetSelector">
     <selectionStates>
-      <SelectionState runConfigName="app">
+      <SelectionState runConfigName="PracticaSensores">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-12-06T02:29:26.154788600Z">
+        <DropdownSelection timestamp="2024-12-16T01:27:06.656936200Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\gabri\.android\avd\Medium_Phone_API_35.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Ryzen\.android\avd\Medium_Phone_API_35.avd" />
             </handle>
           </Target>
         </DropdownSelection>


### PR DESCRIPTION
Se implementa una brújula que orienta al jugador en los 4 puntos cardinales.

Nota: la brújula está orientada en base a la localización en vida real de las instalaciones de la Escuela Superior de Cómputo. Por lo tanto, la orientación queda de la siguiente forma:
- Oeste ---> Norte.
- Norte ---> Este.
- Este ---> Sur.
- Sur ---> Oeste.

Primero se menciona la localización dentro del juego en base al mapa y después se pasa a la localización en la vida real.

https://github.com/user-attachments/assets/8ff37e83-8152-4160-ae96-d2a916cfe848

